### PR TITLE
Typo in index.mdx

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -12,7 +12,7 @@ Welcome to Document, a Gatsby.js theme by [Code Bushi](https://codebushi.com/gat
 Using the Gatsby CLI
 
 ```bash
-gatsby new document-site https://github.com/codebushi/gatsby-starter-dimension.git
+gatsby new document-site https://github.com/codebushi/gatsby-theme-document-example
 cd document-site
 gatsby develop
 ```

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -12,7 +12,7 @@ Welcome to Document, a Gatsby.js theme by [Code Bushi](https://codebushi.com/gat
 Using the Gatsby CLI
 
 ```bash
-gatsby new document-site https://github.com/codebushi/gatsby-theme-document-example
+gatsby new document-site https://github.com/codebushi/gatsby-theme-document-example.git
 cd document-site
 gatsby develop
 ```


### PR DESCRIPTION
There is a typo in the example repo url (It is correct in the README.md)